### PR TITLE
Log also the first state

### DIFF
--- a/run-on-holo1.sh
+++ b/run-on-holo1.sh
@@ -77,6 +77,7 @@ uv run surfer-h-cli \
     --task "$TASK" \
     --url "$URL" \
     --max_n_steps 30 \
+    --headless-browser \
     --base_url_localization "$HAI_MODEL_URL" \
     --model_name_localization "$MODEL" \
     --temperature_localization 0.7 \

--- a/run-on-holo1.sh
+++ b/run-on-holo1.sh
@@ -77,7 +77,6 @@ uv run surfer-h-cli \
     --task "$TASK" \
     --url "$URL" \
     --max_n_steps 30 \
-    --headless-browser \
     --base_url_localization "$HAI_MODEL_URL" \
     --model_name_localization "$MODEL" \
     --temperature_localization 0.7 \

--- a/src/surfer_h_cli/surferh.py
+++ b/src/surfer_h_cli/surferh.py
@@ -316,6 +316,7 @@ def agent_loop(
         url=url,
         screenshots=[browser.screenshot()],
     )
+    set_current_state(current_state)
 
     start_time = time.time()
 


### PR DESCRIPTION
Hi,

thank you very much for your nice work and for releasing the weights of the model.
When I tested your repository and the nice web UI,
it turned out that the very first step (Step 0) is not recorded in the trajectory file nor in the web ui.
The error message was: `Agent state missing trajectory_id, cannot route event`.

I checked it and saw that in `surferh.py` in the `agent_loop` function the `AgentState` is created but only set to the `threading.local()` object via function `set_current_state` in function  `update_state`.
This `update_state` function is only called at the end of the `agent_loop' function, and thus, the first step is not recorded.

I added a call to the `set_current_state` after generating the initial `AgentState`.

Furthermore, when I called the `run-on-holo1.sh` script with a local hosted model, there was an error message from Selenium.
Thus, I added the option `--headless-browser` in this script as well.

Please review my changes, and if you are fine with them, I would be happy if it is included.

Best regards
Sven