### PR TITLE
[Chore] Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 
 
+> [!IMPORTANT]
+> **Surfer-H-CLI has been deprecated and is no longer maintained.**
+>
+> Please use the **[Models API](https://hub.hcompany.ai/about-the-models-api)** and **[Agent API](https://hub.hcompany.ai/computer-use-agents/introduction)** instead. The typed Python/TypeScript clients and CLI now ship as **`hai-agents`** — [PyPI](https://pypi.org/project/hai-agents/) · [npm](https://www.npmjs.com/package/hai-agents) · [SDK docs](https://hub.hcompany.ai/computer-use-agents/integrations).
+
 # Surfer-H-CLI / Open Surfer-H
 
 


### PR DESCRIPTION
## Why
`surfer-h-cli` is deprecated in favor of the unified H APIs and the `hai-agents` SDK. People landing on this repo need a clear redirect to the supported path.

## What
Adds a deprecation callout at the top of the README linking to the Models API, the Agent API, and the `hai-agents` packages (PyPI / npm) plus the SDK docs.

## How to verify
- Open the rendered README — the `[!IMPORTANT]` alert appears at the very top.
- Click through the links (Models API, Agent API, SDK docs, PyPI) — all resolve.

## Follow-up
After merge, an org admin should archive the repo (Settings → Archive this repository, or `gh repo archive hcompai/surfer-h-cli`) so it becomes read-only. Do this **after** merging so the redirect is in place first.

Made with [Cursor](https://cursor.com)